### PR TITLE
Fix CSV card parsing bug

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -23,12 +23,13 @@ def read_csv_cards(file_path):
             # Detect if this is a cloze card by checking for cloze syntax
             is_cloze = '{{c' in front
 
-            if front and back:
+            if front:
                 cards.append({
                     'front': front,
                     'back': back,
                     'deck': deck,
-                    'tags': tags
+                    'tags': tags,
+                    'is_cloze': is_cloze
                 })
     return cards
 


### PR DESCRIPTION
## Summary
- allow importing cloze cards with empty backs
- include `is_cloze` field when reading cards from CSV

## Testing
- `python -m py_compile parse.py`
- `python -m py_compile app.py just_PDFs.py txt_CSV.py`


------
https://chatgpt.com/codex/tasks/task_e_68419951b164832889b7e090bc76ced3