### PR TITLE
Enable cloze cards without tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,20 +15,29 @@ def parse_cards(text):
     cards = []
     lines = text.strip().split('\n')
     for line in lines:
-        # Expect tab-separated front and back
+        # Allow cloze lines without a tab; otherwise require front/back
         if '\t' in line:
             front, back = line.split('\t', 1)
-            front = front.strip()
-            back = back.strip()
+        elif '{{c' in line:
+            front, back = line, ''
+        else:
+            continue
 
-            # Detect cloze by {{c1::...}} style in front
-            is_cloze = '{{c' in front
+        front = front.strip()
+        back = back.strip()
 
-            cards.append({
-                'front': front,
-                'back': back,
-                'is_cloze': is_cloze
-            })
+        # Skip completely empty lines
+        if not front:
+            continue
+
+        # Detect cloze by {{c1::...}} style in front
+        is_cloze = '{{c' in front
+
+        cards.append({
+            'front': front,
+            'back': back,
+            'is_cloze': is_cloze
+        })
     return cards
 
 

--- a/tests/test_parse_cards.py
+++ b/tests/test_parse_cards.py
@@ -53,10 +53,19 @@ def test_cloze_detection():
     assert card['is_cloze'] is True
 
 
-def test_ignore_lines_without_tab():
+def test_ignore_non_cloze_without_tab():
     text = "Front\tBack\nInvalid line without tab\nAnother front\tAnother back"
     result = parse_cards(text)
     assert len(result) == 2
     fronts = [c['front'] for c in result]
     assert 'Front' in fronts
     assert 'Another front' in fronts
+
+
+def test_cloze_without_tab():
+    text = "Front\tBack\n{{c1::Capital of France}} is Paris\nAnother front\tAnother back"
+    result = parse_cards(text)
+    assert len(result) == 3
+    cloze_card = [c for c in result if c['is_cloze']][0]
+    assert cloze_card['front'] == "{{c1::Capital of France}} is Paris"
+    assert cloze_card['back'] == ''


### PR DESCRIPTION
## Summary
- support cloze card lines that omit a tab separator
- keep ignoring non-cloze lines without a tab
- update tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585d92024c832899c80a728250ab4b